### PR TITLE
Create Redis Client Command Parser 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+.ediconfig*
+CMakeUserPresets.json
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+
+include(${CMAKE_BINARY_DIR}/conan_toolchain.cmake)
+
+set(CMAKE_TOOLCHAIN_FILE build/conan_toolchain.cmake)
+
+project(redis-server)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+enable_testing()
+
+add_subdirectory(tests)
+add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# RedisServer
+# RedisServer DIY Project
+
+### RESP Protocol Spec
+https://redis.io/docs/reference/protocol-spec
+
+
+

--- a/conan.sh
+++ b/conan.sh
@@ -1,0 +1,1 @@
+conan install . --output-folder=build --build=missing

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,10 @@
+[requires]
+spdlog/1.12.0
+catch2/3.4.0
+fmt/10.0.0
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+

--- a/inc/logging.h
+++ b/inc/logging.h
@@ -1,0 +1,7 @@
+#ifndef SPDLOG_FMT_EXTERNAL
+    #define SPDLOG_FMT_EXTERNAL
+#endif
+
+#include <spdlog/spdlog.h>
+
+namespace logger = spdlog;

--- a/inc/resp_protocol/command_parser.h
+++ b/inc/resp_protocol/command_parser.h
@@ -1,0 +1,63 @@
+#ifndef __COMMAND_PARSER_H__
+#define __COMMAND_PARSER_H__
+#include <vector>
+#include <string>
+
+#include "resp_protocol/resp_consts.h"
+#include "logging.h"
+
+namespace RedisServer
+{
+    namespace RespProtocol
+    {
+        enum ParserError
+        {
+            kOk = 1,
+            kMissingArrayStartChar,
+            kInvalidFormat,
+            kCommandSizeMismatch,
+            kExtraJunkAfterAllCommandsParsed,
+            kInvalidCommandSize,
+            kMissingBulkArraySize,
+            KUnsupportedCommands,
+            kUnexpectedDataTypeThatShouldBeBulkStrings,
+            kNumberOfCommandsMismatch
+        };
+
+
+        static const std::unordered_map<ParserError, std::string> gParseErrorStringMap = {
+            {ParserError::kOk, "Ok"},
+            {ParserError::kMissingArrayStartChar, "Missing * as start char of command"},
+            {ParserError::kInvalidFormat, "Invalid Format"},
+            {ParserError::kInvalidCommandSize, "Invalid Command Size. Must be a number"},
+            {ParserError::KUnsupportedCommands, "Unuspported Commands"},
+            {ParserError::kMissingBulkArraySize, "Missing Bulk Array Size"},
+            {ParserError::kUnexpectedDataTypeThatShouldBeBulkStrings, "Unexpected DataType Symbol That Should be $ for bulk strings"},
+            {ParserError::kCommandSizeMismatch, "Command Size Mismatch"},
+            {ParserError::kExtraJunkAfterAllCommandsParsed, "Extra chars found after all commands are addded"},
+            {ParserError::kNumberOfCommandsMismatch, "Number of Commands are "}
+
+        };
+
+        /*! \brief Command Parser implements parsing features for client commands send in as Array of Bulk Strings
+         *  \param raw_commands          Command to be parsed sent from Redis client 
+         *  \param error                 Upon parsing success this should return ParserError::kOK or else specific error
+         * 
+         * 
+         * \returns vector of all commands that is parsed properly from raw_commadns input
+         */
+        class CommandParser
+        {
+        public:
+            /*! \brief Parse input strings from Redis client that should be formatted as Aarray of Bulk Strings
+             *
+             *
+            */
+            static std::vector<std::string> Parse(const std::string& raw_commands, ParserError& err); 
+            
+
+};
+    }
+
+}
+#endif // __COMMAND_PARSER_H__

--- a/inc/resp_protocol/resp_consts.h
+++ b/inc/resp_protocol/resp_consts.h
@@ -1,0 +1,30 @@
+#ifndef __RESP_H__
+#define __RESP_H__
+
+#include <unordered_map>
+
+namespace RedisServer {
+
+    namespace RespProtocol{
+
+        enum RespDataType {
+            SimpleStrings = 1,
+            Errors,
+            Integers,
+            BulkStrings,
+            Arrays
+        };
+
+        static const std::unordered_map<RespDataType, char> gRespDataTypePrefixMap = {
+            {SimpleStrings, '+'},
+            {Errors, '-'},
+            {Integers, ':'},
+            {BulkStrings, '$'},
+            {Arrays, '*'},
+        };
+
+    }
+
+}
+
+#endif // __RESP_H__

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+
+find_package(spdlog 1.12.0 REQUIRED)
+find_package(fmt 10.0 REQUIRED)
+
+include_directories("${spdlog_INCLUDE_DIRS}")
+include_directories("${fmt_INCLUDE_DIRS}")
+
+set(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/command_parser.cpp")
+
+add_library(command_parser ${SOURCES})
+
+target_compile_features(command_parser
+	PRIVATE
+	cxx_std_17
+)
+
+target_include_directories(command_parser
+    PUBLIC
+    "${CMAKE_CURRENT_SOURCE_DIR}/../inc"
+)
+
+target_link_libraries(command_parser
+    spdlog::spdlog
+    fmt::fmt
+)

--- a/src/command_parser.cpp
+++ b/src/command_parser.cpp
@@ -1,0 +1,184 @@
+#include "resp_protocol/command_parser.h"
+#include "resp_protocol/resp_consts.h"
+
+using namespace RedisServer;
+
+static bool ToSizeTFromStr(const std::string& str, size_t* val){
+    try{
+        if (!val){
+            throw std::runtime_error("val must be a valid pointer that store convert value");
+        }        
+        *val = std::stol(str);
+    } catch(std::invalid_argument const& ex){
+        logger::error("Failed to convert to size_t. raw str {}. Ex {}", str, ex.what());
+        return false;
+    } catch (std::out_of_range const& ex) {
+        logger::error("Input out of range size_t. raw str {}. Ex {}", str, ex.what());
+        return false; 
+    }
+    return true;
+}
+
+static bool NextTokenStart(const std::string& str, size_t start, size_t* token_start) {
+    size_t r_size_break_idx = str.find('\r', start);
+    size_t n_size_break_idx = str.find('\n', start);
+
+    if (! (start < str.size())){
+        logger::error("CommandParser Error: index token out of range for start {} str size {}", start, str.size());
+        return false;
+    }
+
+    if (r_size_break_idx == std::string::npos or n_size_break_idx == std::string::npos)
+    {
+        logger::error("NextTokenStart Error: Cannot find \r\n after Bulk Arr Size");
+        return false;
+    }
+
+    if (n_size_break_idx != (r_size_break_idx + 1))
+    {
+        logger::error("NextTokenStart Error: \\r\\n is not in the right position after Bulk Arr Size");
+        return false;
+    }
+    if (!token_start){
+        throw std::runtime_error("token_start must be a valid pointer to store value");
+    }
+    *token_start = n_size_break_idx + 1;
+    return true;
+}
+
+
+std::vector<std::string> RespProtocol::CommandParser::Parse(const std::string& raw_commands, ParserError& err){
+     
+    static const char simple_string_start = gRespDataTypePrefixMap.at(RespDataType::Arrays);
+    static const size_t min_command_size {4};
+
+    size_t bulk_arr_size = 0;
+
+    std::vector<std::string> commands {};
+
+    logger::info("Parsing commands: {}", raw_commands);
+    
+    if (raw_commands.size() < min_command_size){
+        err = ParserError::kInvalidFormat;
+        logger::error("CommandParser Error: {}. Command size is less than min required {}", 
+                RespProtocol::gParseErrorStringMap.at(err), min_command_size);
+        return commands;
+    }
+
+    size_t array_start_idx = raw_commands.find(simple_string_start);
+    size_t bulk_array_size_start_idx = array_start_idx + 1;
+    size_t bulk_array_size_end_idx = 0;
+    size_t start_command_size_idx = 0;
+    size_t start_command_str_idx = 0;
+    size_t command_len = 0;
+
+    if (array_start_idx){
+        err = ParserError::kMissingArrayStartChar;
+        logger::error("CommandParser Error: {} Starting char was {}", 
+                    RespProtocol::gParseErrorStringMap.at(err), raw_commands.at(0));
+        return commands;
+    }
+
+    if (!NextTokenStart(raw_commands, bulk_array_size_start_idx, &bulk_array_size_end_idx)){
+        err = ParserError::kMissingBulkArraySize;
+        logger::error("CommandParser Error: {} Bulk Array Size cannot be found {}", 
+                    RespProtocol::gParseErrorStringMap.at(err), raw_commands);
+        return commands;        
+    }
+
+    start_command_size_idx = bulk_array_size_end_idx;
+
+    if (!ToSizeTFromStr(raw_commands.substr(bulk_array_size_start_idx, bulk_array_size_end_idx - 2), 
+                &bulk_arr_size)){
+        err = ParserError::kMissingBulkArraySize;
+        logger::error("CommandParserError: {} Bulk Array Size cannot be found from idx {} Commands {}",
+              bulk_array_size_start_idx, raw_commands);
+        return commands;
+    }
+    logger::info("Bulk Array Size is valid {}", bulk_arr_size);
+    if (!bulk_arr_size){
+        logger::warn("Bulk Array Size is 0. Return empty list !");
+        return commands;
+    }
+
+    while(start_command_size_idx < raw_commands.size()) {
+
+        if (raw_commands.at(start_command_size_idx) != gRespDataTypePrefixMap.at(RespDataType::BulkStrings)){
+            err = ParserError::kUnexpectedDataTypeThatShouldBeBulkStrings;
+            logger::error("CommandParseError: {} at {} found {} expected {}", 
+                    gParseErrorStringMap.at(err), 
+                    start_command_size_idx, 
+                    raw_commands.at(start_command_str_idx),
+                    gRespDataTypePrefixMap.at(RespDataType::BulkStrings));
+            commands.clear();
+            return commands;
+        }
+
+        start_command_size_idx++;
+        if (!NextTokenStart(raw_commands, start_command_size_idx, &start_command_str_idx)){
+            err = ParserError::kInvalidFormat;
+            logger::error("CommandParseError: Missing \r\n while parsing command size at {} cmds {}", 
+                start_command_size_idx, raw_commands);
+            commands.clear();
+            return commands;
+        }
+
+        if (!ToSizeTFromStr(raw_commands.substr(start_command_size_idx, start_command_str_idx - 2), &command_len)){
+            err = ParserError::kInvalidCommandSize;
+            logger::error("CommandParseError:  {} from index {} to index {}", 
+                gParseErrorStringMap.at(err), 
+                start_command_size_idx, 
+                start_command_str_idx - 2
+            );
+            commands.clear();
+            return commands; 
+        }
+
+        // check for ending of command string here 
+        if (!NextTokenStart(raw_commands, start_command_str_idx, &start_command_size_idx)){
+            err = ParserError::kInvalidFormat;
+            logger::error("CommandParseError: Missing \r\n while parsing command size at {} cmds {}", 
+                start_command_size_idx, raw_commands);
+            commands.clear();
+            return commands;
+        }
+
+        commands.push_back(raw_commands.substr(start_command_str_idx, start_command_size_idx - start_command_str_idx - 2));
+        logger::info("CommandParser: new command added {}", commands.at(commands.size() -1));
+        if (commands.at(commands.size() - 1).size() != command_len){
+            err = ParserError::kCommandSizeMismatch;
+            logger::error("CommandParseError: {}. new command size {} new command {} expected command len {} command {}",
+                gParseErrorStringMap.at(err),
+                commands.at(commands.size() - 1).size(), 
+                commands.at(commands.size() - 1), 
+                command_len, 
+                raw_commands
+            );
+            commands.clear();
+            return commands;
+        }
+
+        if (commands.size() == bulk_arr_size && start_command_size_idx < raw_commands.size()){
+            err = ParserError::kExtraJunkAfterAllCommandsParsed;
+            logger::error("CommandParseError: {}. All {} commands are added but still not at the end of raw_commands value",
+                gParseErrorStringMap.at(err), bulk_arr_size
+            );
+            commands.clear();
+            return commands;
+        }
+
+    }
+
+    if (commands.size() != bulk_arr_size){
+        err = ParserError::kNumberOfCommandsMismatch;
+        logger::error("CommandParseError: {} expected {} but received {}",
+            gParseErrorStringMap.at(err),
+            bulk_arr_size,
+            commands.size()
+        );
+        commands.clear();
+        return commands;
+    }
+
+    return commands;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,39 @@
+cmake_minimum_required(VERSION 3.17 FATAL_ERROR)
+
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+find_package(spdlog 1.12.0 REQUIRED)
+find_package(fmt 10.0 REQUIRED)
+find_package(Catch2 3.4.0 REQUIRED)
+
+include_directories("${spdlog_INCLUDE_DIRS}")
+include_directories("${fmt_INCLUDE_DIRS}")
+include_directories("${Catch2_INCLUDE_DIRS}")
+
+set(SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test_command_parser.cpp")
+
+add_executable(test_command_parser ${SOURCES})
+
+#target_include_directories(test_command_parser
+#    PRIVATE
+#    ../inc
+#)
+
+target_compile_features(test_command_parser
+	PRIVATE
+	cxx_std_17
+)
+
+target_link_libraries(test_command_parser 
+        "${Catch2_INCLUDE_DIRS}/../lib/libCatch2Main.a"
+        "${Catch2_INCLUDE_DIRS}/../lib/libCatch2.a"
+        command_parser
+        spdlog::spdlog
+        "${fmt_INCLUDE_DIRS_RELEASE}/../lib/libfmt.a"
+)
+
+message("catch2 Libraries ${Catch2_LIBRARIES}")
+message("catch2 Libraries ${Catch2_INCLUDE_DIRS}")
+
+
+add_test(test_resp_protocol test_command_parser)

--- a/tests/test_command_parser.cpp
+++ b/tests/test_command_parser.cpp
@@ -1,0 +1,158 @@
+#include <catch2/catch_test_macros.hpp>
+#include <cstdlib>
+
+#include "resp_protocol/command_parser.h"
+
+
+using namespace std::string_literals;
+using namespace RedisServer::RespProtocol;
+
+
+
+
+static std::string GenerateTestString(size_t num_commands, 
+                                      size_t max_command_size, 
+                                      std::vector<std::string>& expected_subcmds) {
+    std::string cmd {"*" + std::to_string(num_commands)+"\r\n"};
+    for (int i = 0; i < num_commands; i++){
+        size_t cmd_size = std::rand() % max_command_size;
+        logger::debug("Generate command of size {}", cmd_size);
+        std::string sub_cmd {"$" + std::to_string(cmd_size) + "\r\n"};
+        size_t start_cmd_str = sub_cmd.size();
+        for (int j = 0; j < cmd_size; j++){
+            char new_char = 'a' + rand() % 26; 
+            sub_cmd.push_back(new_char);
+        }
+        expected_subcmds.push_back(sub_cmd.substr(start_cmd_str));
+        cmd += sub_cmd;
+        cmd += "\r\n";
+    }
+    logger::info("Total number of subcommand genreated {}. Commands \r\n {}", num_commands, cmd);
+    return cmd;
+} 
+
+TEST_CASE("Test Command Parser Basic", "Test Resp Protocol"){
+
+    SECTION("Basic Sanity Test")
+    {
+
+        ParserError ec = ParserError::kOk;
+        auto commands = CommandParser::Parse(
+            "*2\r\n$4\r\nLLEN\r\n$6\r\nmylist\r\n"s,
+            ec);
+
+        REQUIRE(ec == ParserError::kOk);
+        REQUIRE(commands.size() == 2);
+        REQUIRE(commands[0].size() == 4);
+        REQUIRE(commands[0] == "LLEN");
+        REQUIRE(commands[1] == "mylist");
+        REQUIRE(commands[1].size() == 6);
+    }
+
+    SECTION("Empty Command Test")
+    {
+
+        ParserError ec = ParserError::kOk;
+        auto commands = CommandParser::Parse(
+            "*0\r\n"s,
+            ec);
+
+        REQUIRE(commands.empty());
+        REQUIRE(ec == ParserError::kOk);
+    }
+
+    SECTION("Number of Commands Mismatch")
+    {
+
+        ParserError ec = ParserError::kOk;
+        auto commands = CommandParser::Parse(
+            "*3\r\n$4\r\nLLEN\r\n$6\r\nmylist\r\n"s,
+            ec);
+
+        REQUIRE(ec == ParserError::kNumberOfCommandsMismatch);
+        REQUIRE(commands.empty());
+    }
+
+    SECTION("Junks after command")
+    {
+
+        ParserError ec = ParserError::kOk;
+        auto commands = CommandParser::Parse(
+            "*4\r\n$4\r\nLLEN\r\n$6\r\nmylist\r\n$2\r\naa\r\n$5\r\n1234b\r\n sss"s,
+            ec);
+
+        REQUIRE(ec == ParserError::kExtraJunkAfterAllCommandsParsed);
+        REQUIRE(commands.empty());
+    }
+
+
+    SECTION("Command Size Mismatch")
+    {
+
+        ParserError ec = ParserError::kOk;
+        auto commands = CommandParser::Parse(
+            "*4\r\n$4\r\nLLEN\r\n$6\r\nmylistaaa\r\n$2\r\naa\r\n$5\r\n1234b\r\n"s,
+            ec);
+
+        REQUIRE(ec == ParserError::kCommandSizeMismatch);
+        REQUIRE(commands.empty());
+    }
+
+    
+    SECTION("Invalid command size that is not a number")
+    {
+
+        ParserError ec = ParserError::kOk;
+        auto commands = CommandParser::Parse(
+            "*4\r\n$4\r\nLLEN\r\n$6\r\nmylist\r\n$lslslslsls\r\naa\r\n$5\r\n1234b\r\n"s,
+            ec);
+
+        REQUIRE(ec == ParserError::kInvalidCommandSize);
+        REQUIRE(commands.empty());
+    }
+
+    SECTION("Empty Command")
+    {
+
+        ParserError ec = ParserError::kOk;
+        auto commands = CommandParser::Parse(
+            "*4\r\n$4\r\nLLEN\r\n$6\r\nmylist\r\n$0\r\n\r\n$5\r\n1234b\r\n"s,
+            ec);
+
+        REQUIRE(ec == ParserError::kOk);
+        REQUIRE(commands.size() == 4);
+        REQUIRE(commands[2].empty());
+    }
+}
+
+TEST_CASE("Stress Test Command Parser", "Test Resp Protocol"){
+       
+    uint32_t seed = time(NULL);
+    logger::info("Stress Test Command Parser Seed: {}", seed);
+    uint32_t num_cycles = 20;
+    uint32_t num_commands = 100;
+    uint32_t max_cmd_size = 30;
+    ParserError ec = ParserError::kOk;
+    std::vector<std::string> expeced_sub_cmds {};
+
+    for (int i = 1; i <= num_cycles; i++){
+        ec = ParserError::kOk;
+        expeced_sub_cmds.clear();
+        logger::info("Stress Test Command Parser Cycle {}", i);
+        std::string command = GenerateTestString(num_commands, 
+                                                 max_cmd_size,
+                                                 expeced_sub_cmds
+                                                 );
+        REQUIRE(num_commands == expeced_sub_cmds.size());
+        auto commands = CommandParser::Parse(command, ec);
+        REQUIRE(commands.size() == num_commands);
+        REQUIRE(commands.size() == expeced_sub_cmds.size());
+        for (int i = 0; i < commands.size(); i++){
+            REQUIRE(commands[i] == expeced_sub_cmds[i]);
+        }
+    }
+}
+
+
+
+


### PR DESCRIPTION
### NEW FEATUREs
- Add new command parser for Redis client based on protocol doc here: https://redis.io/docs/reference/protocol-spec/. The Parser always assumes client will send command with Array of Bulk Strings format.
- Add Sanity Test and Stress Test for the Parser via Catch2 


